### PR TITLE
Add support for slugs with multiple words in

### DIFF
--- a/admin/views/admin-menu.php
+++ b/admin/views/admin-menu.php
@@ -69,8 +69,9 @@ $j(document).ready(function() {
 
      $j( ".edit-entry" ).bind( "click", function() {
             var slug = $j(this).attr("data-slug");
+            var title = $j(this).attr("data-title");
             $clone.prependTo('#uploader-' + slug);
-            $j('.input_file_name').val(slug);
+            $j('.input_file_name').val(title);
     });
     
     $j( ".add-new-file" ).bind( "click", function() {
@@ -165,12 +166,12 @@ $j(document).ready(function() {
             
                <tr>
                  <td style="text-align: center;"><input type="checkbox" name="delete_slugs[]" value="<?php echo $file['slug'];?>" /></td>
-                 <td style="text-align: center;"><a href="#" class="edit-entry" data-slug="<?php echo $file['slug'];?>">Edit</a></td>
+                 <td style="text-align: center;"><a href="#" class="edit-entry" data-title="<?php echo $file['title'];?>" data-slug="<?php echo $file['slug'];?>">Edit</a></td>
                  <td class="row-title">
-                    <a href="<?php echo $this->upload_base_url.'/'.$file['filename']; ?>" target="_blank"><?php echo $file['slug']; ?></a>
+                    <a href="<?php echo $this->upload_base_url.'/'.$file['filename']; ?>" target="_blank"><?php echo $file['title']; ?></a>
                     <div id="uploader-<?php echo $file['slug'];?>"> </div>
                  </td>
-                 <td><code>[wp_excel_cms name="<?php echo $file['slug'];?>"]</code></td><!--$data = wp_excel_cms_get("<?php echo $file['slug'];?>");-->
+                 <td><code>[wp_excel_cms name="<?php echo $file['title'];?>"]</code></td><!--$data = wp_excel_cms_get("<?php echo $file['title'];?>");-->
                  <td><?php echo $this->formatSizeUnits($file['filesize']); ?></td>
                  <td><?php echo date(get_option('date_format'),$file['upload_time']); ?> | <?php echo date(get_option('time_format'),$file['upload_time']); ?></td>
              </tr>

--- a/admin/wp-excel-cms-admin.php
+++ b/admin/wp-excel-cms-admin.php
@@ -298,7 +298,7 @@ function getFileList(){
 	        if(isset($options['sheet_names'])){
 		        foreach($options['sheetNames'] as $sheetId => $sheetName){
 			        if($sheetId != 1){
-			            $res    = @unlink($this->upload_dir.'/'.$options['slug'].'_sheet_'.$sheetId.'.json');
+			            $res    = @unlink($this->upload_dir.'/'.$options['title'].'_sheet_'.$sheetId.'.json');
 			        }
 		        }
 	        }

--- a/admin/wp-excel-cms-admin.php
+++ b/admin/wp-excel-cms-admin.php
@@ -296,9 +296,10 @@ function getFileList(){
             $options = (array) json_decode(file_get_contents($options_file));
 
 	        if(isset($options['sheet_names'])){
-		        foreach($options['sheetNames'] as $sheetId => $sheetName){
+		        foreach($options['sheet_names'] as $sheetId => $sheetName){
 			        if($sheetId != 1){
 			            $res    = @unlink($this->upload_dir.'/'.$options['title'].'_sheet_'.$sheetId.'.json');
+			            $res    = @unlink($this->upload_dir.'/'.$options['title'].'_sheet_'.$sheetId.'.xlsx');
 			        }
 		        }
 	        }

--- a/admin/wp-excel-cms-admin.php
+++ b/admin/wp-excel-cms-admin.php
@@ -193,7 +193,8 @@ function create_excel_file($file_name){
 	$file_ext = end( explode( ".", $_FILES["file"]['name'] ) );
     
     $options = array(
-        'slug'          => $new_file_name,
+        'slug'          => $this->generateSlugName($new_file_name),
+        'title'         => $new_file_name,
         'filename'      => $new_file_name.'.'.$file_ext,
         'json_file'     => $new_file_name.'.json',
         'options_file'  => $new_file_name.'.options.json',
@@ -216,6 +217,17 @@ function create_excel_file($file_name){
     );
     
 }
+	
+	/**
+	 * Generate correct slug for uploaded file
+	 * 
+	 * @param string $new_file_name 
+	 * 
+	 * @return string
+	 */
+	public function generateSlugName($new_file_name) {
+		return strtolower(str_replace(' ', '-', $new_file_name));
+	}
 
 	/**
 	 * @param $jsonData


### PR DESCRIPTION
By default, slug is a filename (which user defined when upload a new file). And in some cases generated slug is a big problem. F.e., jquery-selectors not support whitespaces - slug used in javascript part. Selector like `$('.uploader-products in stock')` will not working. And it is a reason for unavailable edit link, and, maybe, for some other bugs.

But slug like "products-in-stock" will be supported.
